### PR TITLE
DisplayPowerController: Don't apply brightness adjustment if NaN

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -2518,6 +2518,8 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
     }
 
     private void putAutoBrightnessAdjustmentSetting(float adjustment) {
+        if (Float.isNaN(adjustment))
+            return;
         if (mDisplayId == Display.DEFAULT_DISPLAY) {
             mAutoBrightnessAdjustment = adjustment;
             Settings.System.putFloatForUser(mContext.getContentResolver(),


### PR DESCRIPTION
On some devices, old incompatible brightness configs are causing PowerManager to crash randomly although auto brightness seems working just all fine.

Change-Id: I09591f56b4d592d1019a43c639e5e9f0ddbad004