### PR TITLE
SystemUI: Make QS carrier text scrollable again

### DIFF
--- a/packages/SystemUI/res/layout/qs_carrier.xml
+++ b/packages/SystemUI/res/layout/qs_carrier.xml
@@ -28,15 +28,14 @@
     android:clipToPadding="false"
     android:focusable="true" >
 
-    <TextView
+    <com.android.systemui.util.AutoMarqueeTextView
         android:id="@+id/qs_carrier_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:minWidth="150dp"
         android:textAppearance="@style/TextAppearance.QS.Status.Carriers"
         android:textDirection="locale"
-        android:gravity="center_vertical|end"
+        android:marqueeRepeatLimit="marquee_forever"
         android:singleLine="true"
         android:maxEms="7"/>
 


### PR DESCRIPTION
This reverts commit 2b0c477663ec92e124511d200346208e63674abf.

Making the carrier text field non-marquee i.e. fixed boundaried results in an ugly empty space in case of using dual sims. So, for now it's better to move back to marqueed text implementationuntil a better solution is obtained.

Test: m and check expanded qs. No visible unnecessary empty space was obtained.


Change-Id: Ie7f51d7c43c99119cca34a31e1e849bdc0e7eed1